### PR TITLE
Move all run_langevin like methods to use new API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ before_script:
 script:
   - python main_run.py --algorithm="std" --iterations 2 --replicas 2
   - python main_run.py --algorithm="eftad_diffmap_local" --iterations 2 --replicas 2
-
+  - python main_run.py --algorithm="modif_kinEn" --iterations 2 --replicas 2
+  
 env:
   matrix:
     - python=2.7  CONDA_PY=27

--- a/main_run.py
+++ b/main_run.py
@@ -22,8 +22,8 @@ import model
 #create model defined in class model
 mdl=model.Model()
 
-print mdl.x_unit
-print mdl.modelname
+print(mdl.x_unit)
+print(mdl.modelname)
 print('System has %d particle(s)' % mdl.system.getNumParticles())
 #systemName='Ala2Pept'
 
@@ -75,7 +75,7 @@ massScale=50.0
 gammaScale=100.0
 kappaScale=1000.0
 
-print ("TemperatureTAMDFactor = " + repr(TemperatureTAMDFactor))
+print("TemperatureTAMDFactor = " + repr(TemperatureTAMDFactor))
 temperatureAlpha= (T*TemperatureTAMDFactor)* unit.kelvin
 
 print('Gamma is '+repr(gamma))

--- a/main_run.py
+++ b/main_run.py
@@ -67,7 +67,7 @@ kT = kB * temperature
 
 
 gamma = 1.0 / unit.picosecond
-dt = 4.0 * unit.femtosecond
+dt = 2.0 * unit.femtosecond
 
 TemperatureTAMDFactor=30.0
 massScale=50.0
@@ -99,13 +99,14 @@ general_sampler=sampler.Sampler(model=mdl, integrator=integrator, algorithm=iAlg
 
 # nrSteps is number of steps for each nrRep , and iterate the algo nrIterations times - total simulation time is nrSteps x nrIterations
 nrSteps=1000
+nrEquilSteps = 50000
 nrIterations=args.niterations
 nrRep=args.nreplicas
 
 print('Simulation time: '+repr(nrSteps*nrIterations*dt.value_in_unit(unit.femtosecond))+' '+str(unit.femtosecond)+'\n ***** \n' )
 
-print('Equilibration\n')
-general_sampler.run(1000, 1, 1)
+print('Equilibration: 'repr(nrEquilSteps*nrIterations*dt.value_in_unit(unit.femtosecond))+' '+str(unit.femtosecond)+'\n ***** \n' )
+general_sampler.run(nrEquilSteps, 1, 1)
 general_sampler.resetInitialConditions()
 # run the simulation
 print('Starting simulation\n')

--- a/main_run.py
+++ b/main_run.py
@@ -99,13 +99,13 @@ general_sampler=sampler.Sampler(model=mdl, integrator=integrator, algorithm=iAlg
 
 # nrSteps is number of steps for each nrRep , and iterate the algo nrIterations times - total simulation time is nrSteps x nrIterations
 nrSteps=1000
-nrEquilSteps = 50000
+nrEquilSteps = 10000
 nrIterations=args.niterations
 nrRep=args.nreplicas
 
 print('Simulation time: '+repr(nrSteps*nrIterations*dt.value_in_unit(unit.femtosecond))+' '+str(unit.femtosecond)+'\n ***** \n' )
 
-print('Equilibration: 'repr(nrEquilSteps*nrIterations*dt.value_in_unit(unit.femtosecond))+' '+str(unit.femtosecond)+'\n ***** \n' )
+print('Equilibration: '+repr(nrEquilSteps*dt.value_in_unit(unit.femtosecond))+' '+str(unit.femtosecond)+'\n ***** \n' )
 general_sampler.run(nrEquilSteps, 1, 1)
 general_sampler.resetInitialConditions()
 # run the simulation

--- a/srcDiffmap/Langevin.py
+++ b/srcDiffmap/Langevin.py
@@ -144,8 +144,8 @@ class Langevin:
             xs[0,:] = self.x0
             ps[0,:] = self.p0
         except:
-            print 'Dimension of input arguments does not match'
-            print self.x0, self.p0
+            print('Dimension of input arguments does not match')
+            print(self.x0, self.p0)
 
 
 
@@ -249,7 +249,7 @@ class Langevin:
 
 
         except:
-            print 'In simulate_eftad: Dimension of input arguments does not match'
+            print('In simulate_eftad: Dimension of input arguments does not match')
             #print self.x0, self.p0
 
 
@@ -389,7 +389,7 @@ class Langevin:
 
 
         except:
-            print 'In simulate_eftad: Dimension of input arguments does not match'
+            print('In simulate_eftad: Dimension of input arguments does not match')
             #print self.x0, self.p0
 
 
@@ -561,7 +561,7 @@ class Langevin:
 
 
         except:
-            print 'In simulate_eftad kin en: Dimension of input arguments does not match'
+            print('In simulate_eftad kin en: Dimension of input arguments does not match')
             #print self.x0, self.p0
 
 

--- a/srcDiffmap/integrator.py
+++ b/srcDiffmap/integrator.py
@@ -58,11 +58,32 @@ class Integrator():
          # Create a Context for integration
          self.context = openmm.Context(self.model.system, self.langevin_integrator)
 
-    def run_langevin(self,n_steps):
-        """Simulate n_steps of Langevin dynamics using BAOAB"""
+    def run_langevin(self, n_steps, save_interval=1):
+        """Simulate n_steps of Langevin dynamics using Python implementation of BAOAB
 
-        xs = [self.x0]
-        vs = [self.x0]
+        Parameters
+        ----------
+        n_steps : int
+            The number of MD steps to run
+        save_interval : int, optional, default=1
+            The interval at which steps are saved
+
+        Returns
+        -------
+        xyz : list of (natoms,3) unitless positions
+            xyz[n] is the nth frame from the trajectory in units of self.model.x_units,
+            saved with interval save_interval
+
+        TODO
+        ----
+        * Handle box_vectors so that we can eventually run periodic systems
+
+        """
+        if n_steps % save_interval != 0:
+            raise Exception("n_steps (%d) should be an integral multiple of save_interval (%d)" % (n_steps, save_interval))
+
+        # Store trajectory
+        xyz = list()
 
         x = self.x0
         v = self.v0
@@ -72,7 +93,7 @@ class Integrator():
 
         f=self.force_fxn(x)
 
-        for _ in range(n_steps):
+        for step in range(n_steps):
             v = v + ((0.5*self.dt ) * f/ self.masses)
             x = x + ((0.5*self.dt ) * v)
             v = (a * v) + b * np.random.randn(*x.shape) * np.sqrt(self.kT / self.masses)
@@ -80,19 +101,17 @@ class Integrator():
             f=self.force_fxn(x)
             v = v + ((0.5*self.dt ) * f / self.masses)
 
-            xs.append(x)
-            vs.append(v)
+            if (step+1) % save_interval == 0:
+                xyz.append(x / self.model.x_unit)
+                kinTemp = self.computeKineticTemperature(v)
+                self.kineticTemperature.addSample(kinTemp)
 
-
-            kinTemp = self.computeKineticTemperature(v)
-
-            self.kineticTemperature.addSample(kinTemp)
             #print self.kineticTemperature.getAverage()
 
         self.xEnd=x
         self.vEnd=v
 
-        return xs, vs
+        return xyz
 
     def run_openmm_langevin(self, n_steps, save_interval=1):
         """Simulate n_steps of Langevin dynamics using openmmtools BAOAB
@@ -110,6 +129,10 @@ class Integrator():
             xyz[n] is the nth frame from the trajectory in units of self.model.x_units,
             saved with interval save_interval
 
+        TODO
+        ----
+        * Handle box_vectors so that we can eventually run periodic systems
+
         """
         if n_steps % save_interval != 0:
             raise Exception("n_steps (%d) should be an integral multiple of save_interval (%d)" % (n_steps, save_interval))
@@ -124,17 +147,18 @@ class Integrator():
         # Run n_steps of dynamics
         for iteration in range(int(n_steps / save_interval)):
             self.langevin_integrator.step(save_interval)
-            state = self.context.getState(getPositions=True, getVelocities=True)
+            state = self.context.getState(getPositions=True, getVelocities=True, getEnergy=True)
             x = state.getPositions(asNumpy=True)
             v = state.getVelocities(asNumpy=True)
             # Append to trajectory
             xyz.append(x / self.model.x_unit)
+            # Store kinetic temperature
+            kinTemp = state.getKineticEnergy()*2.0/self.ndof/ (unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA)
+            self.kineticTemperature.addSample(kinTemp)
 
         # Save final state
         self.xEnd = x
         self.vEnd = v
-
-        # Retrieve positions and velocities
 
         return xyz
 

--- a/srcDiffmap/integrator.py
+++ b/srcDiffmap/integrator.py
@@ -51,7 +51,7 @@ class Integrator():
          kinTemp = self.computeKineticTemperature(self.v0)
          self.kineticTemperature=Averages.Average(kinTemp)
          self.kineticTemperature.addSample(kinTemp)
-         print self.kineticTemperature.getAverage()
+         print(self.kineticTemperature.getAverage())
 
          # Create a BAOAB integrator
          self.langevin_integrator = openmmtools.integrators.LangevinIntegrator(temperature=self.temperature, collision_rate=self.gamma, timestep=self.dt, splitting='V R O R V')

--- a/srcDiffmap/sampler.py
+++ b/srcDiffmap/sampler.py
@@ -160,6 +160,7 @@ class Sampler():
                     # TODO: Also track initial and final velocities
 
                     self.integrator.x0=initialPositions[rep]
+                    #xyz += self.integrator.run_langevin(nrSteps, save_interval=self.modNr) # local Python
                     xyz += self.integrator.run_openmm_langevin(nrSteps, save_interval=self.modNr)
                     initialPositions[rep] = self.integrator.xEnd
 

--- a/srcDiffmap/sampler.py
+++ b/srcDiffmap/sampler.py
@@ -164,9 +164,6 @@ class Sampler():
                     xyz += self.integrator.run_openmm_langevin(nrSteps, save_interval=self.modNr)
                     initialPositions[rep] = self.integrator.xEnd
 
-                #for n in range(0,nrRep):
-                #    Xit[it* (nrRep*nrSteps) + n]=Xrep[n]
-
                 if(it>0):
                     tavEnd=time.time()
                     self.timeAv.addSample(tavEnd-tav0)
@@ -256,8 +253,6 @@ class Sampler():
 
             for it in range(0,nrIterations):
 
-                Xrep=[self.model.positions for i in range(nrRep*nrSteps)]
-
                 if(it>0):
                     tav0=time.time()
 
@@ -271,22 +266,18 @@ class Sampler():
                         print(time.strftime("Time left %H:%M:%S", time.gmtime(t_left)))
 
                 #------- simulate Langevin
+                xyz = list()
                 for rep in range(0, nrRep):
 
                     self.integrator.x0=initialPositions[rep]
-                    xs,vx=self.integrator.run_langevin(nrSteps)
-                    initialPositions[rep]=xs[-1]
-
-
-                    for n in range(0,nrSteps):
-                        Xrep[rep*nrSteps + n]=xs[n]
+                    xyz += self.integrator.run_openmm_langevin(nrSteps, save_interval=self.modNr)
+                    initialPositions[rep] = xyz[-1]
 
                  #-----save trajectory from the current Iteration
                 #for n in range(0,nrRep*nrSteps):
                 #    Xit[it* (nrRep*nrSteps) + n]=Xrep[n]
 
                 # creat md traj object
-                xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
                 #------ rmsd ------------------------------
 
@@ -305,6 +296,7 @@ class Sampler():
                 #------ compute CV ------------------------------
 
                 landmarks, V1 = dimension_reduction(traj, self.epsilon, self.numberOfLandmarks, self.model, self.T, self.method)
+                #landmarks, V1 = dimension_reduction(self.trajSave, self.epsilon, self.numberOfLandmarks, self.model, self.T, self.method) # EXPERIMENTAL
 
                 # change the epsilon if there is not enough of landmarks
                 escape=0
@@ -355,9 +347,9 @@ class Sampler():
                 else:
 
                     self.integrator.x0=xEftad[-1]
-                xsdecorr,vxdecorr=self.integrator.run_langevin(self.nrDecorrSteps)
+                xyz = self.integrator.run_openmm_langevin(self.nrDecorrSteps, save_interval=self.nrDecorrSteps)
 
-                initialPositions=[xsdecorr[-1] for rep in range(0,nrRep)]
+                initialPositions=[xyz[-1] for rep in range(0,nrRep)]
 
 
                 if(it>0):
@@ -379,7 +371,8 @@ class Sampler():
 
 
     def runDiffmapCV_Eftad_only(self, nrSteps, nrIterations, nrRep):
-        # use the eftad with CV obtained from diffusion map as for sampling
+            """WARNING: run_langevin API has changed, so this currently does not work."""
+            # use the eftad with CV obtained from diffusion map as for sampling
 
             #reset time
             self.timeAv.clear()
@@ -410,6 +403,7 @@ class Sampler():
 
                     self.integrator.x0=initialPositions[rep]
                     if it==0:
+                        # WARNING: run_langevin now returns xyz
                         xs,vx=self.integrator.run_langevin(nrSteps)
                     else:
                         xs,vx=self.integrator.run_EFTAD_adaptive(nrStepsEftad,  dataLM, VLM, v)
@@ -488,8 +482,6 @@ class Sampler():
 
             for it in range(0,nrIterations):
 
-                Xrep=[self.model.positions for i in range(nrRep*nrSteps)]
-
                 if(it>0):
                     tav0=time.time()
 
@@ -501,30 +493,24 @@ class Sampler():
                         print(time.strftime("Time left %H:%M:%S", time.gmtime(t_left)))
 
                 #------- simulate Langevin
+                xyz = list()
+
                 for rep in range(0, nrRep):
 
                     self.integrator.x0=initialPositions[rep]
                     if it==0:
-                        xs,vx=self.integrator.run_langevin(nrSteps)
+                        xyz += self.integrator.run_openmm_langevin(nrSteps, save_interval=self.modNr)
                     else:
-                        xs,vx=self.integrator.run_modifKinEn_Langevin(nrSteps, dataLM, VLM, v)
-                    initialPositions[rep]=xs[-1]
-
-                    for n in range(0,nrSteps):
-                        Xrep[rep*nrSteps + n]=xs[n]
+                        xyz += self.integrator.run_modifKinEn_Langevin(nrSteps, dataLM, VLM, v, save_interval=self.modNr)
+                    initialPositions[rep] = xyz[-1]
 
                  #-----save trajectory from the current Iteration
                 #for n in range(0,nrRep*nrSteps):
                 #    Xit[it* (nrRep*nrSteps) + n]=Xrep[n]
 
-                #------ rmsd ------------------------------
-                #Y=Xrep[::self.modNr]
-                Y=min_rmsd(Xrep[::self.modNr])
-                Y=Y*self.integrator.model.x_unit
-
                 #------ reshape data ------------------------------
 
-                traj=reshapeData(self.integrator.model, Y)
+                traj=reshapeData(self.integrator.model, xyz)
 
                 #------ compute CV ------------------------------
 
@@ -541,9 +527,9 @@ class Sampler():
                     else:
                         escape=1
 
-
-                for nL in range(0, self.numberOfLandmarks):
-                    self.landmarkedStates[it*self.numberOfLandmarks+nL]=Xit[landmarks[nL]]
+                # WARNING: This won't work at the moment because we eliminated Xit
+                #for nL in range(0, self.numberOfLandmarks):
+                #    self.landmarkedStates[it*self.numberOfLandmarks+nL]=Xit[landmarks[nL]]
 
 
 
@@ -573,7 +559,6 @@ class Sampler():
                 tavEnd=time.time()
                 self.timeAv.addSample(tavEnd-tav0)
 
-                xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
 
                 print('Saving traj to file')
@@ -592,7 +577,6 @@ class Sampler():
 
 
             initialPositions=[self.integrator.x0 for rep in range(0,nrRep)]
-            Xit=[self.integrator.x0 for i in range(nrIterations*nrRep*nrSteps)]
 
             ##############################
 
@@ -610,25 +594,18 @@ class Sampler():
 
                 #------- simulate Langevin
 
-                Xrep=[self.model.positions for i in range(0,nrRep*nrSteps)]
+                xyz = list()
 
                 for rep in range(0, nrRep):
 
                     self.integrator.x0=initialPositions[rep]
-                    xs,vx=self.integrator.run_modifKinEn_Langevin(nrSteps)
-                    initialPositions[rep]=xs[-1]
-
-                    for n in range(0,nrSteps):
-                        Xrep[rep*nrSteps + n]=xs[n]
-
-                for n in range(0,nrRep*nrSteps):
-                    Xit[it* (nrRep*nrSteps) + n]=Xrep[n]
+                    xyz += self.integrator.run_modifKinEn_Langevin(nrSteps, save_interval=self.modNr)
+                    initialPositions[rep] = xyz[-1]
 
                 if(it>0):
                     tavEnd=time.time()
                     self.timeAv.addSample(tavEnd-tav0)
 
-                xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
 
                 print('Saving traj to file')
@@ -663,16 +640,12 @@ class Sampler():
 
                 #------- simulate Langevin
 
-                Xrep=[self.model.positions for i in range(0,nrRep*nrSteps)]
-
+                xyz = list()
                 for rep in range(0, nrRep):
 
                     self.integrator.x0=initialPositions[rep]
-                    xs,vx=self.integrator.run_modifKinEn_Langevin(nrSteps)
-                    initialPositions[rep]=xs[-1]
-
-                    for n in range(0,nrSteps):
-                        Xrep[rep*nrSteps + n]=xs[n]
+                    xyz += self.integrator.run_modifKinEn_Langevin(nrSteps, save_interval=self.modNr)
+                    initialPositions[rep] = xyz[-1]
 
                 #for n in range(0,nrRep):
                 #    Xit[it* (nrRep*nrSteps) + n]=Xrep[n]
@@ -684,7 +657,6 @@ class Sampler():
                 #tmpselftraj=np.copy(self.sampled_trajectory)
                 #self.sampled_trajectory=np.concatenate((tmpselftraj,np.copy(Xrep[-1].value_in_unit(self.model.x_unit))))
 
-                xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
                 print('Saving traj to file')
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
@@ -737,7 +709,10 @@ def dimension_reduction(tr, eps, numberOfLandmarks, model, T, method):
             q=q/np.sum(q)
 
         else:
-            kernelDiff=dm.compute_kernel(tr, eps)
+            if isinstance(tr, md.Trajectory):
+                kernelDiff=dm.compute_kernel_mdtraj(tr, eps)
+            else:
+                kernelDiff=dm.compute_kernel(tr, eps)
             P=dm.compute_P(kernelDiff, tr)
             q=kernelDiff.sum(axis=1)
 

--- a/srcDiffmap/sampler.py
+++ b/srcDiffmap/sampler.py
@@ -174,7 +174,7 @@ class Sampler():
                 #self.sampled_trajectory=np.concatenate((tmpselftraj,np.copy(Xrep[-1].value_in_unit(self.model.x_unit))))
 
                 self.trajSave=md.Trajectory(xyz, self.topology)
-                print 'Saving traj to file'
+                print('Saving traj to file')
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
                 #if (nrSteps*nrIterations*nrRep)> 10**6:
             #    self.sampled_trajectory=Xrep[::modNr**2]
@@ -231,7 +231,7 @@ class Sampler():
                 xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
 
-                print 'Saving traj to file'
+                print('Saving traj to file')
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
 
 
@@ -262,7 +262,7 @@ class Sampler():
 
                 if(np.remainder(it, writingEveryNSteps)==0):
                     print('Iteration '+ repr(it))
-                    print ('Kinetic Temperature is '+str(self.integrator.kineticTemperature.getAverage()))
+                    print('Kinetic Temperature is '+str(self.integrator.kineticTemperature.getAverage()))
 
 
                     if(it>0):
@@ -369,7 +369,7 @@ class Sampler():
                 xyz_eftad=[x.value_in_unit(self.model.x_unit) for x in xEftad[::self.modNr]]
                 trajEftad=md.Trajectory(xyz_eftad, self.topology)
 
-                print 'Saving traj to file'
+                print('Saving traj to file')
                 self.trajSave = self.trajSave[::self.modNr]
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
                 trajEftad.save(self.savingFolder+self.algorithmName+'_trajTAMD_'+repr(it)+'.h5')
@@ -464,7 +464,7 @@ class Sampler():
                 xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
 
-                print 'Saving traj to file'
+                print('Saving traj to file')
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
 
 
@@ -575,7 +575,7 @@ class Sampler():
                 xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
 
-                print 'Saving traj to file'
+                print('Saving traj to file')
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
 
 ######----------------- pure kin en from force ---------------------------------
@@ -630,7 +630,7 @@ class Sampler():
                 xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
 
-                print 'Saving traj to file'
+                print('Saving traj to file')
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
 
 
@@ -685,7 +685,7 @@ class Sampler():
 
                 xyz=[x.value_in_unit(self.model.x_unit) for x in Xrep[::self.modNr]]
                 self.trajSave=md.Trajectory(xyz, self.topology)
-                print 'Saving traj to file'
+                print('Saving traj to file')
                 self.trajSave.save(self.savingFolder+self.algorithmName+'_traj_'+repr(it)+'.h5')
 
 


### PR DESCRIPTION
There's still some issues with the second iteration of `runModifiedKineticEnergy()` where units are being messed up for the initial conditions of the second iteration:
```
Iteration 0
Saving traj to file
Iteration 1
Time left 00:00:00
Traceback (most recent call last):
  File "main_run.py", line 113, in <module>
    general_sampler.run(nrSteps, nrIterations, nrRep)
  File "/Users/choderaj/github/zofiatr/DFM.jchodera/srcDiffmap/sampler.py", line 127, in run
    self.runModifiedKineticEnergy(nrSteps, nrIterations, nrRep)
  File "/Users/choderaj/github/zofiatr/DFM.jchodera/srcDiffmap/sampler.py", line 647, in runModifiedKineticEnergy
    xyz += self.integrator.run_modifKinEn_Langevin(nrSteps, save_interval=self.modNr)
  File "/Users/choderaj/github/zofiatr/DFM.jchodera/srcDiffmap/integrator.py", line 361, in run_modifKinEn_Langevin
    x = x + (self.dt  * dK)
TypeError: unsupported operand type(s) for +: 'numpy.ndarray' and 'Quantity'
```